### PR TITLE
Send only a diff for players array most of the time

### DIFF
--- a/client/src/app/game/game.ts
+++ b/client/src/app/game/game.ts
@@ -184,7 +184,14 @@ export async function start({
   });
 
   socket.on("players", (serverPlayers) => {
-    players = serverPlayers;
+    // Players can be the full list of players or just a delta
+    serverPlayers.forEach((serverPlayer, idx) => {
+      if (players && players[idx]) {
+        players[idx] = { ...players[idx], ...serverPlayer };
+      } else {
+        players.push(serverPlayer);
+      }
+    });
     if (isFirstPlayersEvent) {
       refreshScores();
     }
@@ -270,7 +277,6 @@ export async function start({
             : startY + interpolationFactor * (player.y - startY),
       });
     }
-
     for (const snowball of snowballs) {
       const interpolation = snowballInterpolations.get(snowball.id);
 

--- a/client/src/lib/player-options.ts
+++ b/client/src/lib/player-options.ts
@@ -14,7 +14,7 @@ type SantaIconDetails = {
   alt: string;
   label: SantaColor;
 };
-export function getIconDetails(santaColor: SantaColor) {
+export function getIconDetails(santaColor: SantaColor) : SantaIconDetails {
   return {
     image: `santa-${santaColor.toLowerCase()}.png`,
     alt: `A ${santaColor.toLowerCase()} santa icon`,

--- a/server/room.ts
+++ b/server/room.ts
@@ -55,10 +55,45 @@ export async function createRoom(
     onDestroy();
   }
 
+  function diffObjects(previous: any, current: any) {
+    // Assumes that they have the same keys and just checks for differences
+    // returning the keys that are different (with new one's values)
+    let diff = {};
+    for (const key in current) {
+      if (previous[key] !== current[key]) {
+        diff = {
+          ...diff,
+          [key]: current[key],
+        };
+      }
+    }
+    return diff;
+  }
+
   function broadcast(event: string, payload: any) {
     sockets.forEach((socket) => {
       socket.emit(event, payload);
     });
+  }
+
+  const cacheLastBroadcast = new Map<string, any[]>();
+  function broadcast_compressed(event: string, payload: {}[]) {
+    const lastBroadcast = cacheLastBroadcast.get(event);
+    if (lastBroadcast === undefined || lastBroadcast.length === 0) {
+      broadcast(event, payload);
+      cacheLastBroadcast.set(event, structuredClone(payload));
+      return;
+    }
+    // copy the array so we don't mutate the original
+    const newBroadcast = structuredClone(payload);
+    const diffArray = lastBroadcast.map((last: any, idx: number) => {
+      return diffObjects(last, newBroadcast[idx]);
+    });
+    if (diffArray.length === 0) return;
+    if (diffArray.some((diff: any) => Object.keys(diff).length > 0)) {
+      broadcast(event, diffArray);
+    }
+    cacheLastBroadcast.set(event, newBroadcast);
   }
 
   function getPlayer(playerId: string) {
@@ -97,7 +132,7 @@ export async function createRoom(
               victim,
               killer,
             });
-            broadcast("players", players);
+            broadcast_compressed("players", players);
             broadcast("refresh", undefined);
           },
         },
@@ -106,7 +141,7 @@ export async function createRoom(
     }
     snowballs = snowballs.filter((snowball) => snowball.timeLeft > 0);
 
-    broadcast("players", players);
+    broadcast_compressed("players", players);
     broadcast("snowballs", snowballs);
   }
 
@@ -182,6 +217,7 @@ export async function createRoom(
   async function onDisconnect(socket: Socket) {
     sockets = sockets.filter((s) => s.id !== socket.id);
     players = players.filter((player) => player.id !== socket.id);
+    delete inputsMap[socket.id];
 
     try {
       const room = await getRoomInfo(roomId);
@@ -199,7 +235,6 @@ export async function createRoom(
     } catch (err) {
       // still let players play
     }
-
     broadcast("players", players);
     broadcast("refresh", undefined);
   }

--- a/server/room.ts
+++ b/server/room.ts
@@ -77,6 +77,7 @@ export async function createRoom(
   }
 
   const cacheLastBroadcast = new Map<string, any[]>();
+
   function broadcast_compressed(event: string, payload: {}[]) {
     const lastBroadcast = cacheLastBroadcast.get(event);
     if (lastBroadcast === undefined || lastBroadcast.length === 0) {
@@ -84,12 +85,14 @@ export async function createRoom(
       cacheLastBroadcast.set(event, structuredClone(payload));
       return;
     }
-    // copy the array so we don't mutate the original
+
     const newBroadcast = structuredClone(payload);
-    const diffArray = lastBroadcast.map((last: any, idx: number) => {
-      return diffObjects(last, newBroadcast[idx]);
-    });
+    const diffArray = lastBroadcast.map((last: any, idx: number) =>
+      diffObjects(last, newBroadcast[idx])
+    );
+
     if (diffArray.length === 0) return;
+
     if (diffArray.some((diff: any) => Object.keys(diff).length > 0)) {
       broadcast(event, diffArray);
     }


### PR DESCRIPTION
It's a start! Players events seem like the most important to diff, usually only canFire, x, y, or direction change. I originally planned on just making broadcast do this for everything, but there are times where you don't want it (should have been obvious, but it got me) - and for things like snowballs it's useless because everything about them changes while they're spawned (they're moving all the time). 

Let me know if you have suggestions for cleaning it up or a different way to approach it. 


closes #6 

